### PR TITLE
Get rid of vectors that will never contain more than 1 item

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -61,17 +61,17 @@ private:
     
     void workLoop() override;
 
-    vector<cl::Context> m_context;
-    vector<cl::CommandQueue> m_queue;
-    vector<cl::CommandQueue> m_abortqueue;
+    cl::Context m_context;
+    cl::CommandQueue m_queue;
+    cl::CommandQueue m_abortqueue;
     cl::Kernel m_searchKernel;
     cl::Kernel m_dagKernel;
     cl::Device m_device;
+    cl::Buffer m_header;
+    cl::Buffer m_searchBuffer;
 
-    vector<cl::Buffer> m_dag;
-    vector<cl::Buffer> m_light;
-    vector<cl::Buffer> m_header;
-    vector<cl::Buffer> m_searchBuffer;
+    cl::Buffer* m_dag = nullptr;
+    cl::Buffer* m_light = nullptr;
 
     CLSettings m_settings;
 


### PR DESCRIPTION
- Only dag and light need to be free'd and reallocated.
- Use pointers instead of vectors.