### PR TITLE
Revert "Fix missed prog regen if epoch and prog switch coincide"

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -352,7 +352,7 @@ void CLMiner::workLoop()
                     if (!initEpoch(w.block))
                         break;  // This will simply exit the thread
                 }
-                if (old_period_seed != period_seed)
+                else if (old_period_seed != period_seed)
                 {
                     compileKernel(period_seed);
                 }


### PR DESCRIPTION
Reverts gangnamtestnet/progminer#6 Logic was correct after all. compile miner is called in initEpoch.