### PR TITLE
Minor optimizations

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -60,6 +60,7 @@ protected:
 private:
     
     void workLoop() override;
+    bool compileKernel(uint64_t prog_seed);
 
     cl::Context m_context;
     cl::CommandQueue m_queue;
@@ -81,7 +82,6 @@ private:
     cl::Program m_program;
     char m_options[256] = {0};
     int m_computeCapability = 0;
-    bool compileKernel(uint64_t prog_seed);
 };
 
 }  // namespace eth

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -508,12 +508,12 @@ void CUDAMiner::search(
                     h256 mix;
                     uint64_t nonce = nonce_base + buffer.result[i].gid;
                     memcpy(mix.data(), (void*)&buffer.result[i].mix, sizeof(buffer.result[i].mix));
-                    auto sol = Solution{nonce, mix, w, std::chrono::steady_clock::now(), m_index};
 
-                    cudalog << EthWhite << "Job: " << w.header.abridged() << " Sol: "
-                            << toHex(sol.nonce, HexPrefix::Add) << EthReset;
+                    Farm::f().submitProof(
+                        Solution{nonce, mix, w, std::chrono::steady_clock::now(), m_index});
 
-                    Farm::f().submitProof(sol);
+                    cudalog << EthWhite << "Job: " << w.header.abridged() << " Sol: 0x"
+                            << toHex(nonce) << EthReset;
                 }
             }
 

--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -500,9 +500,10 @@ void Farm::submitProofAsync(Solution const& _s)
                   << " gave incorrect result. Lower overclocking values if it happens frequently.";
             return;
         }
+        m_onSolutionFound(Solution{_s.nonce, r.mixHash, _s.work, _s.tstamp, _s.midx});
     }
-
-    m_onSolutionFound(_s);
+    else
+        m_onSolutionFound(_s);
 
 #ifdef DEV_BUILD
     if (g_logOptions & LOG_SUBMIT)

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -98,7 +98,7 @@ struct CUSettings : public MinerSettings
 {
     unsigned streams = 2;
     unsigned schedule = 4;
-    unsigned gridSize = 1024;
+    unsigned gridSize = 256;
     unsigned blockSize = 512;
     unsigned parallelHash = 4;
 };

--- a/progminer/main.cpp
+++ b/progminer/main.cpp
@@ -329,8 +329,8 @@ public:
         app.add_option("--cuda-grid-size,--cu-grid-size", m_CUSettings.gridSize, "", true)
             ->check(CLI::Range(1, 131072));
 
-        app.add_set(
-            "--cuda-block-size,--cu-block-size", m_CUSettings.blockSize, {32, 64, 128, 256}, "", true);
+        app.add_set("--cuda-block-size,--cu-block-size", m_CUSettings.blockSize,
+            {32, 64, 128, 256, 512}, "", true);
 
         app.add_set(
             "--cuda-parallel-hash,--cu-parallel-hash", m_CUSettings.parallelHash, {1, 2, 4, 8}, "", true);
@@ -908,9 +908,9 @@ public:
                  << "    Use this extended CUDA arguments to fine tune the performance." << endl
                  << "    Be advised default values are best generic findings by developers" << endl
                  << endl
-                 << "    --cu-grid-size      INT [1 .. 131072] Default = 8192" << endl
+                 << "    --cu-grid-size      INT [1 .. 131072] Default = 256" << endl
                  << "                        Set the grid size" << endl
-                 << "    --cu-block-size     UINT {32,64,128,256} Default = 128" << endl
+                 << "    --cu-block-size     UINT {32,64,128,256} Default = 512" << endl
                  << "                        Set the block size" << endl
                  << "    --cu-devices        UINT {} Default not set" << endl
                  << "                        Space separated list of device indexes to use" << endl


### PR DESCRIPTION
- CUDA switch time is extremely long, maxing out at about 250 ms.
  (compared to OpenCL switch time of under 1 ms.)
  Reduce default to reduce CUDA switch time to the 25 ms. range.
  Running 2 streams, this will not impact hash rate.

- The isolate parameter is passed arround to virtually all functions
  resulting in a lot a parameter passing code generation. This
  parameter was intended to fool the compiler into not unrolling the
  loop. It doesn't seem to have any impact in OpenCL 1.2, in fact
  the kernel seems to do better without.