### PR TITLE
Reduce default grid size for acceptable job swiitch time

### DIFF
--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -98,7 +98,7 @@ struct CUSettings : public MinerSettings
 {
     unsigned streams = 2;
     unsigned schedule = 4;
-    unsigned gridSize = 2048;
+    unsigned gridSize = 256;
     unsigned blockSize = 512;
     unsigned parallelHash = 4;
 };


### PR DESCRIPTION
- Previous default resulted in avg. 400 ms. job switch time.
- Reduce default grid size to achieve about 50 ms. job switch
  time.
- No performance impact.
- CUDA only update.