### PR TITLE
Preparation for kernel pre-calc and miscellaneous cleanup

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -53,14 +53,14 @@ public:
 protected:
     bool initDevice() override;
 
-    bool initEpoch_internal(uint64_t) override;
+    bool initEpoch_internal() override;
 
     void kick_miner() override;
 
 private:
     
     void workLoop() override;
-    bool compileKernel(uint64_t prog_seed);
+    bool compileKernel(uint64_t prog_seed, cl::Program& program);
 
     cl::Context m_context;
     cl::CommandQueue m_queue;
@@ -83,6 +83,8 @@ private:
     int m_computeCapability = 0;
 
     atomic<bool> m_kickEnabled = {false};
+
+    atomic<int> m_nextPeriod = {0};
 };
 
 }  // namespace eth

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -45,7 +45,7 @@ public:
 protected:
     bool initDevice() override;
 
-    bool initEpoch_internal(uint64_t) override;
+    bool initEpoch_internal() override;
 
     void kick_miner() override;
 
@@ -54,7 +54,6 @@ private:
 
     void workLoop() override;
 
-    CUmodule m_module;
     CUfunction m_kernel;
     std::vector<volatile Search_results*> m_search_buf;
     std::vector<cudaStream_t> m_streams;
@@ -68,8 +67,7 @@ private:
     uint64_t m_allocated_memory_dag = 0; // dag_size is a uint64_t in EpochContext struct
     size_t m_allocated_memory_light_cache = 0;
 
-    void compileKernel(uint64_t prog_seed, uint64_t dag_words);
-
+    void compileKernel(uint64_t prog_seed, uint64_t dag_words, CUfunction& kernel);
 };
 
 

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -123,7 +123,7 @@ float Miner::RetrieveHashRate() noexcept
 void Miner::TriggerHashRateUpdate() noexcept
 {
     bool b = false;
-    if (m_hashRateUpdate.compare_exchange_strong(b, true))
+    if (m_hashRateUpdate.compare_exchange_weak(b, true, std::memory_order_relaxed))
         return;
     // GPU didn't respond to last trigger, assume it's dead.
     // This can happen on CUDA if:
@@ -131,7 +131,7 @@ void Miner::TriggerHashRateUpdate() noexcept
     m_hashRate = 0.0;
 }
 
-bool Miner::initEpoch(uint64_t block_number)
+bool Miner::initEpoch()
 {
     // When loading of DAG is sequential wait for
     // this instance to become current
@@ -150,7 +150,7 @@ bool Miner::initEpoch(uint64_t block_number)
 
     // Run the internal initialization
     // specific for miner
-    bool result = initEpoch_internal(block_number);
+    bool result = initEpoch_internal();
 
     // Advance to next miner or reset to zero for 
     // next run if all have processed
@@ -176,7 +176,7 @@ void Miner::updateHashRate(uint32_t _groupSize, uint32_t _increment) noexcept
 {
     m_groupCount += _increment;
     bool b = true;
-    if (!m_hashRateUpdate.compare_exchange_strong(b, false))
+    if (!m_hashRateUpdate.compare_exchange_weak(b, false, std::memory_order_relaxed))
         return;
     using namespace std::chrono;
     auto t = steady_clock::now();

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -428,12 +428,12 @@ protected:
     /**
      * @brief Initializes miner to current (or changed) epoch.
      */
-    bool initEpoch(uint64_t);
+    bool initEpoch();
 
     /**
      * @brief Miner's specific initialization to current (or changed) epoch.
      */
-    virtual bool initEpoch_internal(uint64_t) = 0;
+    virtual bool initEpoch_internal() = 0;
 
     /**
      * @brief Returns current workpackage this miner is working on

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -296,7 +296,7 @@ void PoolManager::setActiveConnectionCommon(unsigned int idx)
 
     // Are there any outstanding operations ?
     bool ex = false;
-    if (!m_async_pending.compare_exchange_strong(ex, true))
+    if (!m_async_pending.compare_exchange_weak(ex, true, std::memory_order_relaxed))
         throw std::runtime_error("Outstanding operations. Retry ...");
 
     if (idx != m_activeConnectionIdx)

--- a/libpoolprotocols/getwork/EthGetworkClient.cpp
+++ b/libpoolprotocols/getwork/EthGetworkClient.cpp
@@ -40,7 +40,7 @@ void EthGetworkClient::connect()
 {
     // Prevent unnecessary and potentially dangerous recursion
     bool expected = false;
-    if (!m_connecting.compare_exchange_strong(expected, true, memory_order::memory_order_relaxed))
+    if (!m_connecting.compare_exchange_weak(expected, true, memory_order::memory_order_relaxed))
         return;
 
     // Reset status flags
@@ -515,7 +515,7 @@ void EthGetworkClient::send(std::string const& sReq)
     m_txQueue.push(line);
 
     bool ex = false;
-    if (m_txPending.compare_exchange_strong(ex, true, std::memory_order_relaxed))
+    if (m_txPending.compare_exchange_weak(ex, true, std::memory_order_relaxed))
         begin_connect();
 }
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -173,7 +173,7 @@ void EthStratumClient::disconnect()
 {
     // Prevent unnecessary recursion
     bool ex = false;
-    if (!m_disconnecting.compare_exchange_strong(ex, true, memory_order_relaxed))
+    if (!m_disconnecting.compare_exchange_weak(ex, true, memory_order_relaxed))
         return;
 
     m_connected.store(false, memory_order_relaxed);
@@ -1789,7 +1789,7 @@ void EthStratumClient::send(Json::Value const& jReq)
     m_txQueue.push(line);
 
     bool ex = false;
-    if (m_txPending.compare_exchange_strong(ex, true, std::memory_order_relaxed))
+    if (m_txPending.compare_exchange_weak(ex, true, std::memory_order_relaxed))
         sendSocketData();
 }
 


### PR DESCRIPTION
- Make opencl compile return program object
- Make CUDA compile return kernel object
- Fix redundant _strong version of compare_exchange.
  For strongly ordered architectures like x86 both the
  strong and weak implementations are the same.
- Separate Light/DAG and Progpow kernel generation.
  Previously compile was invoked in two ways by the
  work loop, one directly, and once indirectly via
  the initEpoch call.
- Use environment variable based windows TEMP dir.